### PR TITLE
Update krum readme with parameter details.

### DIFF
--- a/examples/krum/README.md
+++ b/examples/krum/README.md
@@ -3,9 +3,11 @@
 
 **Krum proposed in: [Machine Learning with Adversaries: Byzantine Tolerant Gradient Descent](https://papers.nips.cc/paper/6617-machine-learning-with-adversaries-byzantine-tolerant-gradient-descent.pdf)**
 
-This example explains how to run the KRUM fusion algorithm on CNNs implemented with Keras training
+This example explains how to run the Krum fusion algorithm to train CNNs implemented with Keras training
 on [MNIST](http://yann.lecun.com/exdb/mnist/) data. Data in this example preprocessed by scaling down to range from `[0, 255]` to `[0, 1]`.
 No other preprocessing is performed.
+
+**Note that** the parameter `byzantine_threshold` is set to `1` by default. According to Krum's assumption, the number of parties in the FL system should be at least `2 * byzantine_threshold + 3`. Therefore, to run this example, please create at least `5` parties.
 
 - Split data by running:
 


### PR DESCRIPTION
In this PR, we include more details about how to set `byzantine_threshold` and how to choose the correct number of parties to run a Krum example.