### PR TITLE
Automator party number bugfix

### DIFF
--- a/experiment_manager/ibmfl_cli_automator/run.py
+++ b/experiment_manager/ibmfl_cli_automator/run.py
@@ -811,7 +811,7 @@ class Runner:
                 if config_agg_dict is not None and 'agg' in proc_label:
                     orig_config = config_agg_dict
                 elif config_party_dicts is not None and 'party' in proc_label:
-                    orig_config = config_party_dicts[int(proc_label[-1])]
+                    orig_config = config_party_dicts[int(proc_label[5:])]
                 else:
                     with open(file, 'r') as stream:
                         orig_config = yaml.load(stream.read(), Loader=yaml.Loader)


### PR DESCRIPTION
Fixes a bug in ibmfl_cli_automator.run where party numbers are assumed to be one character, causing crashes for experiments with more than ten parties. Fix simply replaces the last character in the proc_label string with all the characters after party, which should allow for over 100 parties as well. This was tested with up to 20 parties.